### PR TITLE
tree/container: guard NULL workspace on detach

### DIFF
--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -1562,7 +1562,8 @@ void container_add_child(struct sway_container *parent,
 }
 
 void container_detach(struct sway_container *child) {
-	if (child->pending.fullscreen_mode == FULLSCREEN_WORKSPACE) {
+	if (child->pending.fullscreen_mode == FULLSCREEN_WORKSPACE &&
+			child->pending.workspace) {
 		child->pending.workspace->fullscreen = NULL;
 	}
 	if (child->pending.fullscreen_mode == FULLSCREEN_GLOBAL) {


### PR DESCRIPTION
Fixes #538

`container_detach()` dereferenced `child->pending.workspace` without a NULL check when the detached container is `FULLSCREEN_WORKSPACE`. Moving a non-leaf container that has a fullscreen descendant to an empty workspace crashes: the first `container_detach()` recursively clears the descendants' `pending.workspace` (via `set_workspace`), then `workspace_unwrap_children()` detaches the still-fullscreen child and writes to `NULL + offsetof(struct sway_workspace, fullscreen)`.

The guard also covers the swayfx-specific dangerous state described in #538: with `scratchpad_minimize enable`, a fullscreen request on a scratchpad-hidden container sets `FULLSCREEN_WORKSPACE` while `pending.workspace` is NULL.

This adds the same guard `container_begin_destroy()` already uses for the identical statement. The bug is inherited from upstream sway; reported there as swaywm/sway#9210 with a matching PR.

## Test plan

Reproducer from #538 in a nested headless instance (swayfx 0.5.3). Two windows are required — with a single window `splitv` only changes the workspace layout and never creates the wrapper container:

```sh
m() { swaymsg -s "$SOCK" "$@"; }  # $SOCK = the nested instance's IPC socket
m create_output
m exec foot; m exec foot; sleep 2
A=$(m -t get_tree | jq '[.. | objects | select(.app_id? == "foot") | .id] | min')
m "[con_id=$A] focus"; m splitv   # wrap A in a split container P
P=$(m -t get_tree | jq --argjson a "$A" '[.. | objects | select(.nodes? and ([.nodes[].id] | index($a)))] | last | .id')
m workspace 3
m "[con_id=$A] fullscreen enable"
m "[con_id=$P] move container to workspace 4"   # 4 = empty
```

Before: SIGSEGV (`segfault at 50 … error 6`, i.e. write at `offsetof(struct sway_workspace, fullscreen)`). After (patched 0.5.3 build): the command succeeds, the fullscreen view lands on the target workspace still fullscreen, and the sibling stays behind. Also running the patched build as my daily compositor. The same reproducer and the same one-line guard were additionally verified on vanilla sway master — coredump backtrace and results in swaywm/sway#9210 / swaywm/sway#9211.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

