### PR TITLE
Fix DRM Backend issue

### DIFF
--- a/INSTALL-deb.md
+++ b/INSTALL-deb.md
@@ -15,7 +15,7 @@ sudo apt update && sudo apt install -y \
   libxcb-dri3-dev libxcb-present-dev libxcb-res0-dev \
   libxcb-render-util0-dev libxcb-ewmh-dev libxcb-icccm4-dev \
   libliftoff-dev libdisplay-info-dev liblcms2-dev libpixman-1-dev \
-  libgles2-mesa-dev
+  libgles2-mesa-dev hwdata libudev-dev
 ```
 
 ## 2\. Setup Build Environment


### PR DESCRIPTION
Added missing hwdata and libudev-dev libraries to required libraries in INSTALL-deb.md
This fixes the DRM backend and libinput issues.