### PR TITLE
feat: basic dwindle layout support

### DIFF
--- a/include/sway/commands.h
+++ b/include/sway/commands.h
@@ -143,6 +143,7 @@ sway_cmd cmd_default_orientation;
 sway_cmd cmd_dim_inactive;
 sway_cmd cmd_dim_inactive_colors_unfocused;
 sway_cmd cmd_dim_inactive_colors_urgent;
+sway_cmd cmd_dwindle;
 sway_cmd cmd_exec;
 sway_cmd cmd_exec_always;
 sway_cmd cmd_exit;

--- a/include/sway/config.h
+++ b/include/sway/config.h
@@ -499,6 +499,7 @@ struct sway_config {
 		float unfocused[4];
 		float urgent[4];
 	} dim_inactive_colors;
+	bool dwindle;
 
 	bool blur_enabled;
 	bool blur_xray;

--- a/sway/commands.c
+++ b/sway/commands.c
@@ -71,6 +71,7 @@ static const struct cmd_handler handlers[] = {
 	{ "dim_inactive", cmd_dim_inactive },
 	{ "dim_inactive_colors.unfocused", cmd_dim_inactive_colors_unfocused },
 	{ "dim_inactive_colors.urgent", cmd_dim_inactive_colors_urgent },
+	{ "dwindle", cmd_dwindle },
 	{ "exec", cmd_exec },
 	{ "exec_always", cmd_exec_always },
 	{ "floating_maximum_size", cmd_floating_maximum_size },

--- a/sway/commands/dwindle.c
+++ b/sway/commands/dwindle.c
@@ -1,0 +1,11 @@
+#include "sway/commands.h"
+#include "util.h"
+
+struct cmd_results *cmd_dwindle(int argc, char **argv) {
+    struct cmd_results *error = NULL;
+    if ((error = checkarg(argc, "dwindle", EXPECTED_EQUAL_TO, 1))) {
+        return error;
+    }
+    config->dwindle = parse_boolean(argv[0], config->dwindle);
+    return cmd_results_new(CMD_SUCCESS, NULL);
+}

--- a/sway/config.c
+++ b/sway/config.c
@@ -290,7 +290,7 @@ static void config_defaults(struct sway_config *config) {
 	config->tiling_drag = true;
 	config->tiling_drag_threshold = 9;
 	config->primary_selection = true;
-
+	config->dwindle = false;
 	config->smart_gaps = SMART_GAPS_OFF;
 	config->gaps_inner = 0;
 	config->gaps_outer.top = 0;

--- a/sway/meson.build
+++ b/sway/meson.build
@@ -67,6 +67,7 @@ sway_sources = files(
 	'commands/default_orientation.c',
 	'commands/dim_inactive.c',
 	'commands/dim_inactive_colors.c',
+	'commands/dwindle.c',
 	'commands/exit.c',
 	'commands/exec.c',
 	'commands/exec_always.c',

--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -2,6 +2,7 @@
 #include <strings.h>
 #include <wayland-server-core.h>
 #include <wlr/config.h>
+#include <wlr/types/wlr_cursor.h>
 #include <wlr/render/wlr_renderer.h>
 #include <wlr/types/wlr_buffer.h>
 #include <wlr/types/wlr_ext_foreign_toplevel_list_v1.h>
@@ -927,7 +928,25 @@ void view_map(struct sway_view *view, struct wlr_surface *wlr_surface,
 
 	struct sway_container *container = view->container;
 	if (target_sibling) {
-		container_add_sibling(target_sibling, container, 1);
+		bool after = 1;
+		if (config->dwindle && seat && seat->cursor){
+			double cx = seat->cursor->cursor->x;
+			double cy = seat->cursor->cursor->y;
+
+			struct sway_container_state *s = &target_sibling->pending;
+
+			double nx = (cx - (s->x + s->width / 2)) / (s->width / 2);
+			double ny = (cy - (s->y + s->height / 2)) / (s->height / 2);
+
+			if (s->width > s->height) {
+				container_split(target_sibling, L_HORIZ);
+				after = nx >= 0;
+			} else {
+				container_split(target_sibling, L_VERT);
+				after = ny >= 0;
+			}
+		}
+		container_add_sibling(target_sibling, container, after);
 	} else if (ws) {
 		container = workspace_add_tiling(ws, container);
 	}


### PR DESCRIPTION
Added basic Dwindle layout support based on mouse position on active(focused) window like [Hyprland](https://wiki.hypr.land/Configuring/Layouts/Dwindle-Layout/), using the `container_add_sibling` function.

# Usage:
Dwindle layout is disabled by default, so to enable it, add `dwindle enable` in your config, or `dwindle disable` to keep it disabled.

# Preview


https://github.com/user-attachments/assets/7ec09eb6-ab62-43fb-9be0-adf3a3428617

