### PR TITLE
poc: slide animation

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ For Fedora users, SwayFX is also available in [copr](https://copr.fedorainfraclo
     - `dim_inactive_colors.urgent <hex color> ex, #900000FF`
 + Keep/remove separator border between titlebar and content: `titlebar_separator enable|disable`
 + Treat Scratchpad as minimized: `scratchpad_minimize enable|disable`: **we recommend keeping this setting off, as there are many kinks to iron out here**
++ Choose the workspace switch transition: `workspace_effect fade|slide|none` (default `fade`); requires `animation_duration_ms` to be non-zero
 
 
 ## Compiling From Source

--- a/include/sway/commands.h
+++ b/include/sway/commands.h
@@ -226,6 +226,7 @@ sway_cmd cmd_unbindsym;
 sway_cmd cmd_unmark;
 sway_cmd cmd_urgent;
 sway_cmd cmd_workspace;
+sway_cmd cmd_workspace_effect;
 sway_cmd cmd_workspace_layout;
 sway_cmd cmd_ws_auto_back_and_forth;
 sway_cmd cmd_xwayland;

--- a/include/sway/config.h
+++ b/include/sway/config.h
@@ -486,11 +486,18 @@ enum xwayland_mode {
 	XWAYLAND_MODE_IMMEDIATE,
 };
 
+enum workspace_effect {
+	WORKSPACE_EFFECT_FADE,
+	WORKSPACE_EFFECT_SLIDE,
+	WORKSPACE_EFFECT_NONE,
+};
+
 /**
  * The configuration struct. The result of loading a config file.
  */
 struct sway_config {
 	float animation_duration_ms;
+	enum workspace_effect workspace_effect;
 	int corner_radius;
 	bool smart_corner_radius;
 

--- a/include/sway/tree/workspace.h
+++ b/include/sway/tree/workspace.h
@@ -59,6 +59,8 @@ struct sway_workspace {
 		struct animation animation;
 		float from_alpha;
 		float to_alpha;
+		int from_offset_x;
+		int to_offset_x;
 	} animation_state;
 };
 
@@ -83,6 +85,8 @@ struct sway_workspace *workspace_auto_back_and_forth(
 bool workspace_switch(struct sway_workspace *workspace);
 
 struct sway_workspace *workspace_by_number(const char* name);
+
+int workspace_get_number(struct sway_workspace *workspace);
 
 struct sway_workspace *workspace_by_name(const char*);
 

--- a/sway/commands.c
+++ b/sway/commands.c
@@ -120,6 +120,7 @@ static const struct cmd_handler handlers[] = {
 	{ "unbindsym", cmd_unbindsym },
 	{ "workspace", cmd_workspace },
 	{ "workspace_auto_back_and_forth", cmd_ws_auto_back_and_forth },
+	{ "workspace_effect", cmd_workspace_effect },
 };
 
 /* Config-time only commands. Keep alphabetized */

--- a/sway/commands/workspace_effect.c
+++ b/sway/commands/workspace_effect.c
@@ -1,0 +1,21 @@
+#include <strings.h>
+#include "sway/commands.h"
+#include "sway/config.h"
+
+struct cmd_results *cmd_workspace_effect(int argc, char **argv) {
+	struct cmd_results *error = NULL;
+	if ((error = checkarg(argc, "workspace_effect", EXPECTED_EQUAL_TO, 1))) {
+		return error;
+	}
+	if (strcasecmp(argv[0], "fade") == 0) {
+		config->workspace_effect = WORKSPACE_EFFECT_FADE;
+	} else if (strcasecmp(argv[0], "slide") == 0) {
+		config->workspace_effect = WORKSPACE_EFFECT_SLIDE;
+	} else if (strcasecmp(argv[0], "none") == 0) {
+		config->workspace_effect = WORKSPACE_EFFECT_NONE;
+	} else {
+		return cmd_results_new(CMD_INVALID,
+				"Expected 'workspace_effect <fade|slide|none>'");
+	}
+	return cmd_results_new(CMD_SUCCESS, NULL);
+}

--- a/sway/config.c
+++ b/sway/config.c
@@ -352,6 +352,7 @@ static void config_defaults(struct sway_config *config) {
 
 	// SwayFX defaults
 	config->animation_duration_ms = 0.0f;
+	config->workspace_effect = WORKSPACE_EFFECT_FADE;
 
 	config->corner_radius = 0;
 	config->smart_corner_radius = false;

--- a/sway/desktop/transaction.c
+++ b/sway/desktop/transaction.c
@@ -132,6 +132,27 @@ static void workspace_fade_complete_callback(void *data) {
 	}
 }
 
+static void workspace_slide_update_callback(void *data) {
+	struct sway_workspace *ws = data;
+	if (!ws || !ws->output) {
+		return;
+	}
+	struct sway_output *output = ws->output;
+	struct wlr_box *area = &output->usable_area;
+	struct side_gaps *gaps = &ws->current_gaps;
+	int offset = get_animated_value(ws->animation_state.from_offset_x,
+		ws->animation_state.to_offset_x, &ws->animation_state.animation);
+
+	wlr_scene_node_set_position(&ws->layers.tiling->node,
+		gaps->left + area->x + offset, gaps->top + area->y);
+
+	for (int i = 0; i < ws->current.floating->length; i++) {
+		struct sway_container *floater = ws->current.floating->items[i];
+		wlr_scene_node_set_position(&floater->scene_tree->node,
+			floater->current.x + offset, floater->current.y);
+	}
+}
+
 /* Compensate for scene-graph reparenting by computing the drift between
  * the last tracked global coordinates and the actual current global position,
  * then applying that delta to the local scene node position
@@ -891,7 +912,7 @@ static void arrange_output(struct sway_output *output, int width, int height) {
 		&& output->wlr_output->enabled && config->animation_duration_ms > 0 &&
 		!(old_active->current.fullscreen || new_active->current.fullscreen);
 
-	if (is_ws_switch) {
+	if (is_ws_switch && config->workspace_effect == WORKSPACE_EFFECT_FADE) {
 		new_active->animation_state.from_alpha = 0.0f;
 
 		if (old_active->current.tiling->length == 0
@@ -914,6 +935,50 @@ static void arrange_output(struct sway_output *output, int width, int height) {
 				workspace_fade_update_callback, workspace_fade_complete_callback);
 			add_animation(&new_active->animation_state.animation,
 				workspace_fade_update_callback, workspace_fade_complete_callback);
+		}
+	} else if (is_ws_switch && config->workspace_effect == WORKSPACE_EFFECT_SLIDE) {
+		int old_num = workspace_get_number(old_active);
+		int new_num = workspace_get_number(new_active);
+		int direction;
+		if (old_num >= 0 && new_num >= 0 && old_num != new_num) {
+			direction = new_num > old_num ? 1 : -1;
+		} else {
+			int old_idx = -1, new_idx = -1;
+			for (int i = 0; i < output->current.workspaces->length; i++) {
+				struct sway_workspace *ws = output->current.workspaces->items[i];
+				if (ws == old_active) {
+					old_idx = i;
+				}
+				if (ws == new_active) {
+					new_idx = i;
+				}
+			}
+			direction = (old_idx < 0 || new_idx >= old_idx) ? 1 : -1;
+		}
+		// direction 1 slides the new workspace in from the right (and the
+		// old one out to the left); -1 reverses it.
+		int distance = output->usable_area.width;
+
+		if (old_active->current.tiling->length == 0
+				&& old_active->current.floating->length == 0) {
+			new_active->animation_state.from_offset_x = direction * distance;
+			new_active->animation_state.to_offset_x = 0;
+			add_animation(&new_active->animation_state.animation,
+				workspace_slide_update_callback, NULL);
+		} else {
+			int current_offset = get_animated_value(old_active->animation_state.from_offset_x,
+				old_active->animation_state.to_offset_x, &old_active->animation_state.animation);
+			old_active->animation_state.from_offset_x = current_offset;
+			old_active->animation_state.to_offset_x = -direction * distance;
+
+			finish_animation(&new_active->animation_state.animation);
+			new_active->animation_state.from_offset_x = direction * distance;
+			new_active->animation_state.to_offset_x = 0;
+
+			add_animation(&old_active->animation_state.animation,
+				workspace_slide_update_callback, workspace_fade_complete_callback);
+			add_animation(&new_active->animation_state.animation,
+				workspace_slide_update_callback, workspace_fade_complete_callback);
 		}
 	}
 
@@ -953,9 +1018,11 @@ static void arrange_output(struct sway_output *output, int width, int height) {
 			} else {
 				struct wlr_box *area = &output->usable_area;
 				struct side_gaps *gaps = &child->current_gaps;
+				int offset_x = get_animated_value(child->animation_state.from_offset_x,
+					child->animation_state.to_offset_x, &child->animation_state.animation);
 
 				wlr_scene_node_set_position(&child->layers.tiling->node,
-					gaps->left + area->x, gaps->top + area->y);
+					gaps->left + area->x + offset_x, gaps->top + area->y);
 
 				arrange_workspace_tiling(child,
 					area->width - gaps->left - gaps->right,
@@ -963,15 +1030,17 @@ static void arrange_output(struct sway_output *output, int width, int height) {
 				arrange_workspace_floating(child);
 			}
 		} else if (animating && !activated) {
-			// Workspace fading out - keep visible, alpha handled by render path
+			// Workspace fading/sliding out - keep visible, effect handled by render path
 			struct wlr_box *area = &output->usable_area;
 			struct side_gaps *gaps = &child->current_gaps;
+			int offset_x = get_animated_value(child->animation_state.from_offset_x,
+				child->animation_state.to_offset_x, &child->animation_state.animation);
 
 			wlr_scene_node_set_enabled(&child->layers.tiling->node, true);
 			wlr_scene_node_set_enabled(&child->layers.fullscreen->node, false);
 
 			wlr_scene_node_set_position(&child->layers.tiling->node,
-				gaps->left + area->x, gaps->top + area->y);
+				gaps->left + area->x + offset_x, gaps->top + area->y);
 
 			arrange_workspace_tiling(child,
 				area->width - gaps->left - gaps->right,

--- a/sway/meson.build
+++ b/sway/meson.build
@@ -146,6 +146,7 @@ sway_sources = files(
 	'commands/unmark.c',
 	'commands/urgent.c',
 	'commands/workspace.c',
+	'commands/workspace_effect.c',
 	'commands/workspace_layout.c',
 	'commands/ws_auto_back_and_forth.c',
 	'commands/xwayland.c',

--- a/sway/sway.5.scd
+++ b/sway/sway.5.scd
@@ -422,6 +422,14 @@ animation_duration_ms <value>
 	Determines the duration of the animation applied to opening and closing
 	windows, between 0 (no animation) and 5000 (5 seconds).
 
+workspace_effect fade|slide|none
+	Determines the animation played when switching the active workspace on
+	an output. _fade_ (the default) cross-fades the outgoing and incoming
+	workspace. _slide_ slides the outgoing workspace off-screen while the
+	incoming one slides in from the opposite side, similar to a
+	swipe-between-desktops transition. _none_ disables the transition.
+	Has no effect while _animation_duration_ms_ is 0.
+
 *assign* <criteria> [→] [workspace] [number] <workspace>
 	Assigns windows matching _criteria_ (see *CRITERIA* for details) to
 	_workspace_. The → (U+2192) is optional and cosmetic. This command is

--- a/sway/tree/workspace.c
+++ b/sway/tree/workspace.c
@@ -224,6 +224,8 @@ struct sway_workspace *workspace_create(struct sway_output *output,
 	ws->animation_state.animation = init_animation(ws);
 	ws->animation_state.from_alpha = 1.0f;
 	ws->animation_state.to_alpha = 1.0f;
+	ws->animation_state.from_offset_x = 0;
+	ws->animation_state.to_offset_x = 0;
 
 	ws->gaps_outer = config->gaps_outer;
 	ws->gaps_inner = config->gaps_inner;
@@ -542,7 +544,7 @@ struct sway_workspace *workspace_by_name(const char *name) {
 	}
 }
 
-static int workspace_get_number(struct sway_workspace *workspace) {
+int workspace_get_number(struct sway_workspace *workspace) {
 	char *endptr = NULL;
 	errno = 0;
 	long long n = strtoll(workspace->name, &endptr, 10);


### PR DESCRIPTION
Disclaimer: this is just a purely vibecoded poc, because I had some time to kill and wanted to test it, but I wrote this PR message by myself

Hi,

I really like the "slide" animation, when switching workspaces, probably mostly because I am an ex mac user and use the 3 finger gesture there a lot, so I wanted to test if that is also possible with swayfx.

This poc implements it, it still is a little buggy when attaching/releasing outputs, but after some tests it looked kinda nice.
Are you interested in having different animation styles for workspace switching?

I'll leave it as a draft for now, also feel free to just close it if you are not comfortable with it being vibecoded (for now), I will take a look at it a little more within this week when I got more time.

https://github.com/user-attachments/assets/468adddf-8a93-4255-915d-b51c187bcc86

And of course, thank you very much for maintaining and providing this fork!



