### PR TITLE
Add per-animation-type animation durations

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,10 @@ For Fedora users, SwayFX is also available in [copr](https://copr.fedorainfraclo
 
 ## New Configuration Options
 
-+ Animations: `animation_duration_ms <integer value 0-5000>`
++ Animations: `animation_duration_ms <integer value 0-5000>` sets the default
+    duration for all animation types; `animation_duration_ms.open`,
+    `animation_duration_ms.close`, `animation_duration_ms.move`, and
+    `animation_duration_ms.workspace` override it per type.
 + Window blur:
     - `blur enable|disable`
     - `blur_xray enable|disable`: this will set floating windows to blur based on the background, not the windows below. You probably want to set this to `disable` :)

--- a/include/sway/animation_manager.h
+++ b/include/sway/animation_manager.h
@@ -7,13 +7,23 @@
 struct sway_container;
 struct sway_server;
 
+enum sway_animation_type {
+	ANIM_WINDOW_OPEN,
+	ANIM_WINDOW_CLOSE,
+	ANIM_WINDOW_MOVE,
+	ANIM_WORKSPACE_SWITCH,
+	ANIM_TYPE_LAST,
+};
+
 // TODO: make animation just a pointer to progress, make multiplier and callback private
 struct animation {
 	struct wl_list link;
 	float progress;
+	float progress_delta;
 	void *data;
 	float multiplier;
 	bool initialized;
+	enum sway_animation_type type;
 	void (*update)(void *);
 	void (*complete)(void *);
 };
@@ -24,14 +34,16 @@ struct animation init_animation(void *data);
 
 void refresh_animation_manager_timing();
 
-void add_animation(struct animation *animation, void (*update_callback)(void *),
-	void (*complete_callback)(void *));
+void add_animation(struct animation *animation, enum sway_animation_type type,
+	void (*update_callback)(void *), void (*complete_callback)(void *));
 
 void finish_animation(struct animation *animation);
 
 void start_animations();
 
 float get_animated_value(float from, float to, const struct animation *animation);
+
+float animation_manager_duration_ms(enum sway_animation_type type);
 
 #endif
 

--- a/include/sway/commands.h
+++ b/include/sway/commands.h
@@ -110,6 +110,10 @@ sway_cmd cmd_exec_process;
 
 sway_cmd cmd_allow_tearing;
 sway_cmd cmd_animation_duration_ms;
+sway_cmd cmd_animation_duration_ms_close;
+sway_cmd cmd_animation_duration_ms_move;
+sway_cmd cmd_animation_duration_ms_open;
+sway_cmd cmd_animation_duration_ms_workspace;
 sway_cmd cmd_assign;
 sway_cmd cmd_bar;
 sway_cmd cmd_bindcode;

--- a/include/sway/config.h
+++ b/include/sway/config.h
@@ -11,6 +11,7 @@
 #include <xkbcommon/xkbcommon.h>
 #include <xf86drmMode.h>
 #include "../include/config.h"
+#include "animation_manager.h"
 #include "gesture.h"
 #include "list.h"
 #include "stringop.h"
@@ -491,6 +492,8 @@ enum xwayland_mode {
  */
 struct sway_config {
 	float animation_duration_ms;
+	float animation_duration_ms_by_type[ANIM_TYPE_LAST];
+	bool animation_duration_ms_set[ANIM_TYPE_LAST];
 	int corner_radius;
 	bool smart_corner_radius;
 

--- a/sway/animation_manager.c
+++ b/sway/animation_manager.c
@@ -10,7 +10,6 @@
 
 struct animation_manager {
 	float tick_time;
-	float progress_delta;
 	struct wl_event_source *tick;
 	struct wl_list animations;
 } animation_manager;
@@ -19,8 +18,10 @@ struct animation init_animation(void *data) {
 	return (struct animation){
 		.data = data,
 		.progress = 0.0f,
+		.progress_delta = 0.0f,
 		.multiplier = 0.0f,
 		.initialized = false,
+		.type = ANIM_WINDOW_OPEN,
 		.update = NULL,
 		.complete = NULL,
 	};
@@ -33,7 +34,7 @@ static float ease_out_cubic(float p) {
 static int animation_timer() {
 	struct animation *animation, *tmp;
 	wl_list_for_each_reverse_safe(animation, tmp, &animation_manager.animations, link) {
-		animation->progress = MIN(animation->progress + animation_manager.progress_delta, 1.0f);
+		animation->progress = MIN(animation->progress + animation->progress_delta, 1.0f);
 		animation->multiplier = ease_out_cubic(animation->progress);
 
 		if (animation->update) {
@@ -55,9 +56,10 @@ static int animation_timer() {
 	return 0;
 }
 
-void add_animation(struct animation *animation, void (*update_callback)(void *),
-		void (*complete_callback)(void *)) {
-	if (!config->animation_duration_ms) {
+void add_animation(struct animation *animation, enum sway_animation_type type,
+		void (*update_callback)(void *), void (*complete_callback)(void *)) {
+	float duration_ms = animation_manager_duration_ms(type);
+	if (duration_ms <= 0) {
 		if (complete_callback) {
 			complete_callback(animation->data);
 		}
@@ -69,8 +71,10 @@ void add_animation(struct animation *animation, void (*update_callback)(void *),
 	}
 
 	animation->progress = 0.0f;
+	animation->progress_delta = animation_manager.tick_time / duration_ms;
 	animation->multiplier = 0.0f;
 	animation->initialized = true;
+	animation->type = type;
 	animation->update = update_callback;
 	animation->complete = complete_callback;
 	wl_list_insert(&animation_manager.animations, &animation->link);
@@ -86,7 +90,7 @@ void finish_animation(struct animation *animation) {
 }
 
 void start_animations() {
-	if (!config->animation_duration_ms) {
+	if (wl_list_empty(&animation_manager.animations)) {
 		return;
 	}
 	assert(animation_manager.tick);
@@ -111,7 +115,20 @@ void refresh_animation_manager_timing() {
 		return;
 	}
 	animation_manager.tick_time = get_fastest_output_refresh_ms();
-	animation_manager.progress_delta = animation_manager.tick_time / config->animation_duration_ms;
+
+	// rescale in-flight animations to their type's current duration
+	struct animation *animation, *tmp;
+	wl_list_for_each_safe(animation, tmp, &animation_manager.animations, link) {
+		float duration_ms = animation_manager_duration_ms(animation->type);
+		if (duration_ms <= 0) {
+			finish_animation(animation);
+			if (animation->complete) {
+				animation->complete(animation->data);
+			}
+			continue;
+		}
+		animation->progress_delta = animation_manager.tick_time / duration_ms;
+	}
 }
 
 void animation_manager_init(struct sway_server *server) {
@@ -126,9 +143,17 @@ static float lerp(float a, float b, float t) {
 }
 
 float get_animated_value(float from, float to, const struct animation *animation) {
-	if (!config->animation_duration_ms || !animation->initialized) {
+	if (!animation->initialized) {
 		return to;
 	}
 	return lerp(from, to, animation->multiplier);
+}
+
+// falls back to the shared default when this type has no override
+float animation_manager_duration_ms(enum sway_animation_type type) {
+	if (config->animation_duration_ms_set[type]) {
+		return config->animation_duration_ms_by_type[type];
+	}
+	return config->animation_duration_ms;
 }
 

--- a/sway/commands.c
+++ b/sway/commands.c
@@ -43,6 +43,10 @@ struct cmd_results *checkarg(int argc, const char *name, enum expected_args type
 /* Keep alphabetized */
 static const struct cmd_handler handlers[] = {
 	{ "animation_duration_ms", cmd_animation_duration_ms },
+	{ "animation_duration_ms.close", cmd_animation_duration_ms_close },
+	{ "animation_duration_ms.move", cmd_animation_duration_ms_move },
+	{ "animation_duration_ms.open", cmd_animation_duration_ms_open },
+	{ "animation_duration_ms.workspace", cmd_animation_duration_ms_workspace },
 	{ "assign", cmd_assign },
 	{ "bar", cmd_bar },
 	{ "bindcode", cmd_bindcode },

--- a/sway/commands/animation_duration_ms.c
+++ b/sway/commands/animation_duration_ms.c
@@ -4,24 +4,57 @@
 #include "sway/animation_manager.h"
 #include "sway/commands.h"
 
-struct cmd_results *cmd_animation_duration_ms(int argc, char **argv) {
+static struct cmd_results *animation_duration_ms_command(int argc, char **argv,
+		const char *cmd_name, float *duration, bool *explicit_flag) {
 	struct cmd_results *error = NULL;
-	if ((error = checkarg(argc, "animation_duration_ms", EXPECTED_AT_LEAST, 1))) {
+	if ((error = checkarg(argc, cmd_name, EXPECTED_AT_LEAST, 1))) {
 		return error;
 	}
 
 	char *err;
-	float val = strtof(argc == 1 ? argv[0] : argv[1], &err);
+	float val = strtof(argv[0], &err);
 	if (*err) {
-		return cmd_results_new(CMD_INVALID, "animation_duration_ms float invalid");
+		return cmd_results_new(CMD_INVALID, "%s float invalid", cmd_name);
 	}
 
 	if (val < 0 || val > 5000) { // surely no one wants an animation longer than 5 seconds
-		return cmd_results_new(CMD_FAILURE, "animation_duration_ms value out of bounds");
+		return cmd_results_new(CMD_FAILURE, "%s value out of bounds", cmd_name);
 	}
 
-	config->animation_duration_ms = val;
+	*duration = val;
+	if (explicit_flag) {
+		*explicit_flag = true;
+	}
 	refresh_animation_manager_timing();
 
 	return cmd_results_new(CMD_SUCCESS, NULL);
+}
+
+struct cmd_results *cmd_animation_duration_ms(int argc, char **argv) {
+	return animation_duration_ms_command(argc, argv, "animation_duration_ms",
+			&config->animation_duration_ms, NULL);
+}
+
+struct cmd_results *cmd_animation_duration_ms_open(int argc, char **argv) {
+	return animation_duration_ms_command(argc, argv, "animation_duration_ms.open",
+			&config->animation_duration_ms_by_type[ANIM_WINDOW_OPEN],
+			&config->animation_duration_ms_set[ANIM_WINDOW_OPEN]);
+}
+
+struct cmd_results *cmd_animation_duration_ms_close(int argc, char **argv) {
+	return animation_duration_ms_command(argc, argv, "animation_duration_ms.close",
+			&config->animation_duration_ms_by_type[ANIM_WINDOW_CLOSE],
+			&config->animation_duration_ms_set[ANIM_WINDOW_CLOSE]);
+}
+
+struct cmd_results *cmd_animation_duration_ms_move(int argc, char **argv) {
+	return animation_duration_ms_command(argc, argv, "animation_duration_ms.move",
+			&config->animation_duration_ms_by_type[ANIM_WINDOW_MOVE],
+			&config->animation_duration_ms_set[ANIM_WINDOW_MOVE]);
+}
+
+struct cmd_results *cmd_animation_duration_ms_workspace(int argc, char **argv) {
+	return animation_duration_ms_command(argc, argv, "animation_duration_ms.workspace",
+			&config->animation_duration_ms_by_type[ANIM_WORKSPACE_SWITCH],
+			&config->animation_duration_ms_set[ANIM_WORKSPACE_SWITCH]);
 }

--- a/sway/desktop/transaction.c
+++ b/sway/desktop/transaction.c
@@ -184,7 +184,8 @@ static void transaction_destroy(struct sway_transaction *transaction) {
 						(con->animation_state.from_height * (1.0f - POPIN_FACTOR)) / 2.0f;
 					con->animation_state.to_width = con->animation_state.from_width * POPIN_FACTOR;
 					con->animation_state.to_height = con->animation_state.from_height * POPIN_FACTOR;
-					add_animation(&con->animation_state.animation, anim_update_callback, close_anim_complete_callback);
+					add_animation(&con->animation_state.animation, ANIM_WINDOW_CLOSE,
+						anim_update_callback, close_anim_complete_callback);
 				} else {
 					container_destroy(node->sway_container);
 				}
@@ -729,9 +730,12 @@ static void _arrange_container(struct sway_container *con,
 
 static void arrange_container(struct sway_container *con,
 		int width, int height, int x, int y, bool title_bar, int gaps) {
-	if (!config->animation_duration_ms || !con->view
-			|| con->animation_state.seat_is_resizing
-			|| con->animation_state.seat_is_moving_float) {
+	bool is_open = con->animation_state.from_x == -1;
+	enum sway_animation_type anim_type = is_open ? ANIM_WINDOW_OPEN : ANIM_WINDOW_MOVE;
+
+	if (!con->view || con->animation_state.seat_is_resizing
+			|| con->animation_state.seat_is_moving_float
+			|| animation_manager_duration_ms(anim_type) <= 0) {
 		finish_animation(&con->animation_state.animation);
 
 		_arrange_container(con, width, height, x, y, title_bar, gaps);
@@ -762,7 +766,7 @@ static void arrange_container(struct sway_container *con,
 		con->animation_state.from_width = width * POPIN_FACTOR;
 		con->animation_state.from_height = height * POPIN_FACTOR;
 		con->animation_state.from_alpha = 0.0f;
-		add_animation(&con->animation_state.animation, anim_update_callback, NULL);
+		add_animation(&con->animation_state.animation, ANIM_WINDOW_OPEN, anim_update_callback, NULL);
 	} else {
 		// move animation
 		snap_animation_position(con);
@@ -770,7 +774,7 @@ static void arrange_container(struct sway_container *con,
 		con->animation_state.from_height = con->animation_state.current_height;
 		con->animation_state.from_alpha = get_animated_value(con->animation_state.from_alpha,
 			con->animation_state.to_alpha, &con->animation_state.animation);
-		add_animation(&con->animation_state.animation, anim_update_callback, NULL);
+		add_animation(&con->animation_state.animation, ANIM_WINDOW_MOVE, anim_update_callback, NULL);
 	}
 
 	// arrange at starting state to "win" position race between animation start and the reparent
@@ -888,7 +892,7 @@ static void arrange_output(struct sway_output *output, int width, int height) {
 	struct sway_workspace *old_active = output->prev_active_workspace;
 
 	bool is_ws_switch = old_active && old_active != new_active
-		&& output->wlr_output->enabled && config->animation_duration_ms > 0 &&
+		&& output->wlr_output->enabled && animation_manager_duration_ms(ANIM_WORKSPACE_SWITCH) > 0 &&
 		!(old_active->current.fullscreen || new_active->current.fullscreen);
 
 	if (is_ws_switch) {
@@ -897,7 +901,7 @@ static void arrange_output(struct sway_output *output, int width, int height) {
 		if (old_active->current.tiling->length == 0
 				&& old_active->current.floating->length == 0) {
 			new_active->animation_state.to_alpha = 1.0f;
-			add_animation(&new_active->animation_state.animation,
+			add_animation(&new_active->animation_state.animation, ANIM_WORKSPACE_SWITCH,
 				workspace_fade_update_callback, NULL);
 		} else {
 			new_active->animation_state.to_alpha = 0.0f;
@@ -910,9 +914,9 @@ static void arrange_output(struct sway_output *output, int width, int height) {
 			new_active->animation_state.from_alpha = 0.0f;
 			new_active->animation_state.to_alpha = 1.0f;
 
-			add_animation(&old_active->animation_state.animation,
+			add_animation(&old_active->animation_state.animation, ANIM_WORKSPACE_SWITCH,
 				workspace_fade_update_callback, workspace_fade_complete_callback);
-			add_animation(&new_active->animation_state.animation,
+			add_animation(&new_active->animation_state.animation, ANIM_WORKSPACE_SWITCH,
 				workspace_fade_update_callback, workspace_fade_complete_callback);
 		}
 	} else if (old_active && new_active && old_active != new_active

--- a/sway/sway.5.scd
+++ b/sway/sway.5.scd
@@ -418,10 +418,6 @@ set|plus|minus|toggle <amount>
 The following commands may be used either in the configuration file or at
 runtime.
 
-animation_duration_ms <value>
-	Determines the duration of the animation applied to opening and closing
-	windows, between 0 (no animation) and 5000 (5 seconds).
-
 *assign* <criteria> [→] [workspace] [number] <workspace>
 	Assigns windows matching _criteria_ (see *CRITERIA* for details) to
 	_workspace_. The → (U+2192) is optional and cosmetic. This command is
@@ -701,6 +697,25 @@ The default colors are:
 :  #ffffff
 :  #000000
 :  #0c0c0c
+
+*animation_duration_ms* <value>
+	Sets the default animation duration in milliseconds, used by any
+	animation type below that has no override of its own, between 0 (no
+	animation) and 5000 (5 seconds). Default: 0
+
+*animation_duration_ms.open* <value>
+	Overrides *animation_duration_ms* for the window-open animation.
+
+*animation_duration_ms.close* <value>
+	Overrides *animation_duration_ms* for the window-close animation.
+
+*animation_duration_ms.move* <value>
+	Overrides *animation_duration_ms* for tiling/floating move and resize
+	animations.
+
+*animation_duration_ms.workspace* <value>
+	Overrides *animation_duration_ms* for the workspace-switch fade
+	animation.
 
 *corner_radius* <radius>
 	Set corner radius in pixels for new windows.


### PR DESCRIPTION
# Individual animation speeds

Changes animation_duration_ms away from single global animation variable.
added independent duration overrides per animation type

added:
animation_duration_ms.open
animation_duration_ms.close
animation_duration_ms.move
animation_duration_ms.workspace

Original animation_duration_ms still works as a "default" for the individual values.

struct animation gains a type and its own progress_delta so animations track their own timing instead of